### PR TITLE
Allow search by PID using pid:<ARTICLE_PID>

### DIFF
--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -6,6 +6,7 @@
    <field name="_version_" type="long" indexed="true" stored="true"/>
 
    <field name="id" type="string" indexed="true" stored="true" multiValued="false"/>
+   <field name="pid" type="PID" indexed="true" stored="false" multiValued="false"/>
    <field name="in" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="type" type="string" indexed="true" stored="true"/>
    <field name="au" type="text" indexed="true" stored="true" multiValued="true"/>
@@ -93,6 +94,9 @@
  <!-- indice de revista -->
  <copyField source="ta_var" dest="ta"/>
 
+ <!-- allow search by article PID -->
+ <copyField source="id" dest="pid"/>
+
  <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
 
@@ -160,6 +164,17 @@
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
     <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
+
+    <fieldType name="PID" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.PatternTokenizerFactory" pattern="^art-(.*)-[a-z]+" group="1"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>      
+    </fieldType>
 
     <!-- since fields of this type are by default not stored or indexed,
          any data added to them will be ignored outright.  -->


### PR DESCRIPTION
A pesquisa deve ser realizada usando o índice pid. Exemplo: pid:S0102-311X2013000800005

Infelizmente não foi possível adicionar a chave de pesquisa diretamente na pesquisa livre pois para isso é necessário que o PID já esteja no formato final no XML de indexação. Como é para uso interno acredito que não seja um problema.

É necessário realizar o restart do serviço (tomcat) após a atualização e realizar a re-indexação da coleção.