### PR TITLE
 #414 ajustes no link do Scielo Analytics no periodico

### DIFF
--- a/iahx/templates/custom/result-inc-source.html
+++ b/iahx/templates/custom/result-inc-source.html
@@ -8,7 +8,7 @@
         </a>
 
         <ul class="dropdown-menu articleShare articleShareMetrics">
-            <li class="dropdown-header">{{ texts.JOURNAL_METRICS }}</li>        
+            <li class="dropdown-header">{{ texts.JOURNAL_METRICS }}</li>
             <li>
                 <ul class="metricTable">
                     <li>
@@ -27,13 +27,13 @@
                 <ul class="metricTable">
                     <li>
                         <a target="_blank" href="
-                        {{ config.metrics.analytics_metrics_url|trim }}?document={{doc.issn.0}}&amp;collection={{doc.in.0}}">
+                        {{ config.metrics.analytics_metrics_url|trim }}?journal={{doc.issn.0}}&amp;collection={{doc.in.0}}">
                             <div class="logo-statistc logo-statistc-scielo"></div>
                         </a>
                     </li>
                     <li>
                         <a target="_blank" href="
-                        {{ config.metrics.analytics_metrics_url|trim }}?document={{doc.issn.0}}&amp;collection={{doc.in.0}}">
+                        {{ config.metrics.analytics_metrics_url|trim }}?journal={{doc.issn.0}}&amp;collection={{doc.in.0}}">
                             SciELO Analytics
                         </a>
                     </li>


### PR DESCRIPTION
#### O que esse PR faz?
Ajuste o link para ir para a pagina do periódico do Analytics, pois antes estava levando para as pagina genericas do Analytics, como citado no comentario do ticker 
https://github.com/scieloorg/search-journals/issues/414#issuecomment-466992184

#### Onde a revisão poderia começar?
Pelo arquivo `iahx/templates/custom/result-inc-source.html`

#### Como este poderia ser testado manualmente?
Apos atualizar o ambiente verificar se ao clicar no Scielo Analytics, devera ir a pagina do periodico no analytics

#### Quais são tickets relevantes?
#414 