### PR TITLE
Alteração dos links de acesso ao documento

### DIFF
--- a/iahx/static/css/scielo-portal.min.css
+++ b/iahx/static/css/scielo-portal.min.css
@@ -1713,6 +1713,18 @@ button.btn:active {
 }
 .searchForm .results .versions span {
   white-space: nowrap;
+  margin-right: 0;
+}
+.searchForm .results .versions span.separator {
+  padding: 0 5px;
+}
+.searchForm .results .versions span a{
+  text-transform: uppercase;
+  margin-left: 5px;
+}
+.searchForm .results .versions span a:first-child{
+  content: "";
+  margin-left: 0;
 }
 .searchForm .results .metadata {
   font-size: .85em;

--- a/iahx/static/css/scielo-portal.min.css
+++ b/iahx/static/css/scielo-portal.min.css
@@ -1726,6 +1726,14 @@ button.btn:active {
   content: "";
   margin-left: 0;
 }
+.searchForm .results .versions span a.abstract:before{
+  content: '>';
+  font-family: "courier new", monaco, monospace;
+  display: inline-block;
+}
+.searchForm .results .versions span a.abstract.opened:before{
+  transform: rotate(90deg);
+}
 .searchForm .results .metadata {
   font-size: .85em;
   padding: 7px 0 7px 5px !important;

--- a/iahx/templates/custom/result-doc-actions.html
+++ b/iahx/templates/custom/result-doc-actions.html
@@ -1,38 +1,104 @@
 
 {% block btn_fulltext %}
+
     <div class="line versions">
-        <span>
+  
+        {% if doc.available_languages|length > 0 %}
+
+            <!--
+                Resumo
+            -->
+            {% if texts.RESULT.LABEL_ABSTRACT %}
+
+                <span>
+
+                {{ texts.RESULT.LABEL_ABSTRACT }}: 
+                
+                {% for language in doc.available_languages %}
+                    
+                    {% set ab_lang = 'ab_' ~ language %}
+                    {% set fulltext_lang = 'fulltext_html_' ~ language %}
+                    {% set pdf_lang = 'fulltext_pdf_' ~ language %}
+
+                    <a href="#" onclick="$('#{{doc.id}}_{{language}}').toggle(); return false;" class="showTooltip" title="{{ translate(language, 'REFINE_la') }}">
+                        {{ translate(language) }}
+                    </a>
+                    
+                {% endfor %}
+
+                </span>
+
+            {% endif %}
+
+
+            <!--
+                Texto
+            -->
+            {% if texts.TEXT %}
+
+                <span class="separator">|</span>
+                <span>
+
+                 {{ texts.TEXT }}: 
+                
+                {% for language in doc.available_languages %}
+                    
+                    {% set ab_lang = 'ab_' ~ language %}
+                    {% set fulltext_lang = 'fulltext_html_' ~ language %}
+                    {% set pdf_lang = 'fulltext_pdf_' ~ language %}
+
+                    <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/scielo.php?script=sci_arttext&pid={{doc.ur.0}}&lng={{lang}}&tlng={{language}}" class="showTooltip" title="{{ translate(language, 'REFINE_la') }}">
+                        {{ translate(language) }}
+                    </a>
+                    
+                {% endfor %}
+
+                </span>
+
+            {% endif %}
+
+
+            <!--
+                PDF
+            -->        
             {% for language in doc.available_languages %}
-                · {{ translate(language, 'REFINE_la') }}:
+
                 {% set ab_lang = 'ab_' ~ language %}
                 {% set fulltext_lang = 'fulltext_html_' ~ language %}
                 {% set pdf_lang = 'fulltext_pdf_' ~ language %}
 
-                {% if attribute(doc, ab_lang) %}
-                    <a href="#" onclick="$('#{{doc.id}}_{{language}}').toggle(); return false;">
-                        {{ texts.RESULT.LABEL_ABSTRACT }}
-                    </a>
-                {% endif %}
-                {% if attribute(doc, fulltext_lang) %}
-                    {% if attribute(doc, ab_lang) %} | {% endif %}
-                    <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/scielo.php?script=sci_arttext&pid={{doc.ur.0}}&lng={{lang}}&tlng={{language}}">
-                        {{ texts.TEXT }}
-                    </a>
-                {% endif %}
                 {% if attribute(doc, pdf_lang) %}
-                    {% if attribute(doc, ab_lang) or attribute(doc, fulltext_lang) %} | {% endif %}
-                    <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/scielo.php?script=sci_pdf&pid={{doc.ur.0}}&lng={{lang}}&tlng={{language}}">
-                        PDF
-                    </a>
-                    {% if doc.doi and doc.in.0 == 'scl' %}
-                    | <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/readcube/epdf.php?doi={{doc.doi}}&pid={{doc.ur.0}}&pdf_path={{ attribute(doc, pdf_lang).0|substring_after('pdf/') }}&lang={{language}}">
-                        ePDF
-                    </a>
-                    {% endif %}
-                {% endif %}
+                    <span class="separator">|</span>
+                    <span>  
+                                            
+                        PDF: 
+                        <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/scielo.php?script=sci_pdf&pid={{doc.ur.0}}&lng={{lang}}&tlng={{language}}" class="showTooltip" title="{{ translate(language, 'REFINE_la') }}">
+                            {{ translate(language) }}
+                        </a>
+
+                        {% if doc.doi and doc.in.0 == 'scl' %}
+
+                            <span class="separator">|</span>
+                            <span class="e-pdf">
+                                ePDF:
+                                <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/readcube/epdf.php?doi={{doc.doi}}&pid={{doc.ur.0}}&pdf_path={{ attribute(doc, pdf_lang).0|substring_after('pdf/') }}&lang={{language}}" class="showTooltip" title="{{ translate(language, 'REFINE_la') }}">
+                                    {{ translate(language) }}
+                                </a>
+                            </span>
+                        {% endif %}
+
+                    </span>
+
+                 {% endif %}
+                
             {% endfor %}
-        </span>
+
+
+        {% endif %}     
+        
     </div>
+
+
     {% for language in doc.available_languages %}
         {% set ab_lang = 'ab_' ~ language %}
         <div id="{{doc.id}}_{{language}}" class="abstract" style="display:none">

--- a/iahx/templates/custom/result-doc-actions.html
+++ b/iahx/templates/custom/result-doc-actions.html
@@ -15,12 +15,8 @@
                 {{ texts.RESULT.LABEL_ABSTRACT }}: 
                 
                 {% for language in doc.available_languages %}
-                    
-                    {% set ab_lang = 'ab_' ~ language %}
-                    {% set fulltext_lang = 'fulltext_html_' ~ language %}
-                    {% set pdf_lang = 'fulltext_pdf_' ~ language %}
 
-                    <a href="#" onclick="$('#{{doc.id}}_{{language}}').toggle(); return false;" class="showTooltip" title="{{ translate(language, 'REFINE_la') }}">
+                    <a href="#" onclick="$(this).toggleClass('opened');$('#{{doc.id}}_{{language}}').slideToggle(); return false;" class=" showTooltip abstract" title="{{ translate(language, 'REFINE_la') }}">
                         {{ translate(language) }}
                     </a>
                     
@@ -39,13 +35,9 @@
                 <span class="separator">|</span>
                 <span>
 
-                 {{ texts.TEXT }}: 
+                {{ texts.TEXT }}: 
                 
                 {% for language in doc.available_languages %}
-                    
-                    {% set ab_lang = 'ab_' ~ language %}
-                    {% set fulltext_lang = 'fulltext_html_' ~ language %}
-                    {% set pdf_lang = 'fulltext_pdf_' ~ language %}
 
                     <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/scielo.php?script=sci_arttext&pid={{doc.ur.0}}&lng={{lang}}&tlng={{language}}" class="showTooltip" title="{{ translate(language, 'REFINE_la') }}">
                         {{ translate(language) }}
@@ -63,8 +55,6 @@
             -->        
             {% for language in doc.available_languages %}
 
-                {% set ab_lang = 'ab_' ~ language %}
-                {% set fulltext_lang = 'fulltext_html_' ~ language %}
                 {% set pdf_lang = 'fulltext_pdf_' ~ language %}
 
                 {% if attribute(doc, pdf_lang) %}
@@ -93,11 +83,9 @@
                 
             {% endfor %}
 
-
         {% endif %}     
         
     </div>
-
 
     {% for language in doc.available_languages %}
         {% set ab_lang = 'ab_' ~ language %}


### PR DESCRIPTION
#### O que esse PR faz?
Altera a forma dos links de acesso aos documentos.
Antes estava organizado por idiomas, agora está organizado por tipo de informação.

#### Onde a revisão poderia começar?
Efetue uma busca no search, e verifique a barra cinza nos itens de listagem.
Na barra cinza, denominada user-actions, agora é possível identificar os documentos organizados primeiramente por tipo de documento e posteriormente por idiomas

#### Como este poderia ser testado manualmente?
Execute os passos anteriores

#### Algum cenário de contexto que queira dar?
--

### Screenshots
<img width="821" alt="Screen Shot 2019-07-09 at 3 29 16 PM" src="https://user-images.githubusercontent.com/22373640/60913710-5b115980-a25e-11e9-9243-98c3b32a6e1c.png">


#### Quais são tickets relevantes?
#429 

### Referências
--



