### PR TITLE
restaurar foco no campo de busca apos clicar no botao limpar

### DIFF
--- a/iahx/static/js/main.js
+++ b/iahx/static/js/main.js
@@ -344,6 +344,8 @@ searchFormBuilder = {
 		});
 
 		$("textarea.form-control:visible",p).on("keyup",searchFormBuilder.TextareaAutoHeight).trigger("keyup");
+		
+		//$("a.clearIptText",p).on("click",searchFormBuilder.ClearPrevInput);
 		$("a.clearIptText",p).on("click",searchFormBuilder.ClearPrevInput);
 
 		$(p).on("keypress",function(e) {
@@ -859,15 +861,34 @@ searchFormBuilder = {
 		$(".showContextHelper").on("focus.showContextHelper blur.showContextHelper",function(e) {
 			var t = $(this),
 				contextHelper = $(t.data("helper")),
-				cl = "contextHelper_focus";
-
+				cl = "contextHelper_focus",
+				ht = false; //have text
+			
 			if(contextHelper.length > 0) {
-				if(e.type == "focus")
-					contextHelper.addClass(cl);
-				else {
-					setTimeout(function() {
-						contextHelper.removeClass(cl);
-					},500)
+				if(e.type == "focus"){
+
+					if (!contextHelper.hasClass(cl)){
+						contextHelper.addClass(cl);
+					}else{	
+						return false;
+					}
+					
+				}else {
+
+					if(e.type == "blur"){
+						if($(".clearIptText").is(":visible")){
+							var ht = true;
+						}
+					}
+					if(!ht){
+						setTimeout(function() {
+							contextHelper.removeClass(cl);
+						},500);	
+					}
+						
+					$(".clearIptText").on("click", function(e){
+						$(".showContextHelper").focus();
+					});
 				}
 			}
 		});


### PR DESCRIPTION
#### O que esse PR faz?
Dá foco no campo de busca logo após clicar no botão de limpar

#### Onde a revisão poderia começar?
main.js linha 861.
Nessa função foram adicionados alguns ifs para conseguir o comportamento desejado sem afetar as demais funcionalidades.

#### Como este poderia ser testado manualmente?
Acesse a home do search. 
1 - Ao clicar no campo de busca, o link de ajuda deve aparecer. 
2 - Ao digitar, o botão de limpar deve aparecer. 
3 - Ao clicar no botão de limpar, o campo deve ser limpo e o foco permanecer no campo de busca.
4 - Ao tirar o foco do campo de busca:
   a) se não houver texto, o link de ajuda deve sumir
   b) se houver texto, apenas retira o foco do campo de busca e continua exibindo o link de ajuda.

#### Algum cenário de contexto que queira dar?
Não.

### Screenshots
--

#### Quais são tickets relevantes?
#377 

### Referências
--



