### PR TITLE
correção de erro de evento ao abrir menu no search

### DIFF
--- a/iahx/static/js/main.js
+++ b/iahx/static/js/main.js
@@ -15,7 +15,7 @@ var Portal = {
 				t.removeClass("opened");
 				d.slideUp("fast");
 			} else {
-				t.Class("opened");
+				t.addClass("opened");
 				d.slideDown("fast");
 			}
 		});


### PR DESCRIPTION
#### O que esse PR faz?
Corrige um problema que existia no script responsável por abrir o menu no search

#### Onde a revisão poderia começar?
main.js na linha 18.
O argumento para adicionar uma classe estava errado. Foi corrigido.

#### Como este poderia ser testado manualmente?
Abra o sistema, e na home, abra o menu. O mesmo deve abrir sem apresentar erros de js no console.

#### Algum cenário de contexto que queira dar?
--

### Screenshots
![Screen Shot 2019-08-13 at 2 38 57 PM](https://user-images.githubusercontent.com/22373640/62963845-2140ef00-bdd8-11e9-9f93-4d27f5dd4b44.png)

#### Quais são tickets relevantes?
#417 

### Referências
--



