### PR TITLE
Exibe os DOIs de acordo com as diretrizes do Crossref

### DIFF
--- a/iahx/templates/custom/result-doc.html
+++ b/iahx/templates/custom/result-doc.html
@@ -143,7 +143,7 @@
             <div class="line metadata">
 				<div class="col-md-12 col-sm-12">
                     {% if doc.doi %}
-                       <span class="DOIResults">DOI: {{ doc.doi }}</span>
+                       <span class="DOIResults"><a href="https://doi.org/{{ doc.doi }}" target="_blank">https://doi.org/{{ doc.doi }}</a></span>
                     {% endif %}
                     {% if doc.total_access %}
 					    <span>


### PR DESCRIPTION
#### O que esse PR faz?
Este altera a exibição dos DOIs na página dos resultado.

#### Onde a revisão poderia começar?
- `iahx/templates/custom/result-doc.html` L`146`

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente, deve-se:
- Iniciar uma instância do search journals;
- Realizar buscas por artigos que possuam `DOI`;
- Verificar que abaixo da barra de idiomas um link completo para o doi foi criado.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
![ezgif-7-68b8c61df28d](https://user-images.githubusercontent.com/4604104/74276579-bde73980-4cf4-11ea-9b3a-ffd4562eeb21.gif)

#### Quais são tickets relevantes?
N/A

### Referências
[[1] - Crossref DOI Guidelines_pt](https://docs.google.com/document/d/1K3Lj031Q6LqYxo33Byh0EzywskO-ywkKg526ENqYa54/edit#)