### PR TITLE
Adiciona a pasta de log no docker-compose para persistência em volume

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,6 +19,7 @@ services:
             - solrcontroller
         volumes:
             - ./iahx:/var/www/site # SciELO Search Journals
+            - ./iahx/logs:/var/www/site/logs
         links:
             - mailhog:mailhog
             - solrcontroller:solrcontroller

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
             - solrcontroller
         volumes:
             - ./iahx:/var/www/site # SciELO Search Journals
+            - ./iahx/logs:/var/www/site/logs
         links:
             - mailhog:mailhog
             - solrcontroller:solrcontroller


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a pasta de log no docker-compose para persistência em volume, no docker-compose.

#### Onde a revisão poderia começar?

- docker-compose-dev.yml

- docker-composeyml


#### Como este poderia ser testado manualmente?

Subir a aplicação com `docker-compose -f docker-compose-dev.yml up -d ` e verificar que os arquivos de logs estão sendo armazenados em `iahx/logs`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#458 

### Referências
N/A

