### PR TITLE
resolução do bug - selecionar itens - remover todos da lista

### DIFF
--- a/iahx/static/js/my_selection.js
+++ b/iahx/static/js/my_selection.js
@@ -39,15 +39,24 @@ function manipulate_bookmark(func, id) {
 // if confirms message, clean the list and go to the main page
 function clean_bookmark(phrase) {
     if(confirm(phrase)) {
+        
         manipulate_bookmark('c');
-        $(".my_selection").attr('checked', false);
-        var form = document.searchForm;
+        
+        var form = document.searchForm,
+            itens = $(".results .item input.checkbox");
+
+            itens.each(function() {
+                $(this).prop("checked",false);
+            });
+            $(".selectAll").prop("checked",false);
+            $(".selectAll").data("all","0");
 
         if (form.q.value.substring(0,4) == '+id:'){
             form.q.value = "";
+
+            form.submit();
         }
         form.from.value = 0;
-        form.submit();
     }
 
 }

--- a/iahx/templates/custom/base.html
+++ b/iahx/templates/custom/base.html
@@ -127,7 +127,7 @@
     <!-- /custom scielo -->
 
     {% block script %}
-    <script language="javascript" type="text/javascript" src="{{ constant("STATIC_URL") }}js/my_selection.js?v=58"></script>
+    <script language="javascript" type="text/javascript" src="{{ constant("STATIC_URL") }}js/my_selection.js"></script>
     <script language="javascript" type="text/javascript" src="{{ constant("STATIC_URL") }}js/clusters.js"></script>
     <script language="javascript" type="text/javascript" src="{{ constant("STATIC_URL") }}js/bootstrap-affix.js"></script>
     <script language="javascript" type="text/javascript" src="{{ constant("STATIC_URL") }}js/vendor/selectize.js"></script> 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige um bug existente.
Ao selecionar todos os itens da lista de resultados, remover alguns itens e selecionar a opção remover todos da lista, alguns itens permanecem checados.

Agora, com este ajuste, ao selecionar a opção "remover todos da lista", todos os itens perdem a seleção.

Caso se trate de uma lista de itens previamente selecionados com a opção "Listar itens", a lista é limpa e é feito o redirecionamento para o formulário de busca.

#### Onde a revisão poderia começar?
1 - Faça uma busca
2 - Selecione alguns itens
3 - no contador de itens selecionados, clique na opção "apagar todos da lista"
4 - Veja que todos os itens perdem a seleção.

*Caso se trate de uma lista de itens previamente selecionados com a opção "Listar itens", a lista é limpa e é feito o redirecionamento para o formulário de busca.

#### Como este poderia ser testado manualmente?
Siga os passos descritos anteriormente.

#### Algum cenário de contexto que queira dar?
Acredito que seja interessante a validação do @alexxxmendonca 

### Screenshots
--

#### Quais são tickets relevantes?
#483 

### Referências
--

