### PR TITLE
Corrige endereço de acesso a documento citante na tela de resultados

### DIFF
--- a/iahx/views/citing-document.php
+++ b/iahx/views/citing-document.php
@@ -45,6 +45,7 @@ $app->get('citing-documents/{id}/', function (Request $request, $id) use ($app, 
         $output_array['citation_id'] = $id;
         $output_array['citing_docs'] = $responses;
         $output_array['lang'] = $lang;
+        $output_array['config'] = $config;
     }
 
     echo $app['twig']->render(custom_template($view . '/result-citing-docs.html'), $output_array);


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o endereço de acesso a um documento citante na tela de resultados de uma busca.

#### Onde a revisão poderia começar?
Por commit.

#### Como este poderia ser testado manualmente?
Para testá-lo seria preciso instalar o search-journals e indexar algumas citações (com o search-journals-proc).
Após, bastaria buscar por referências citadas e acessar os documentos citantes (ao clicar no botão "citado X vezes").

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
Tela que mostra um resultado do tipo "referência citada". Em destaque, está a parte que mostra os documentos citantes. Clicando no título do documento, o link deve ser acessado de modo correto.

![image](https://user-images.githubusercontent.com/2096125/87699264-fccd5f80-c76a-11ea-90fd-48f1c75ac63e.png)

#### Quais são tickets relevantes?
Indique uma issue ao qual o pull request faz relacionamento.

### Referências
N/A

