### PR TITLE
Remove menu para acesso a painel de mais informações de periódico citado

### DIFF
--- a/iahx/templates/custom/result-citation-article.html
+++ b/iahx/templates/custom/result-citation-article.html
@@ -18,24 +18,7 @@
 
 <!-- Citation journal title -->
 {% if doc.cit_journal_title %}
-    <a href="#" class="showTooltip dropdown-toggle source" data-toggle="dropdown" data-placement="top" data-original-title="{{ texts.SHOW_DETAILS }}">{{ doc.cit_journal_title }}</a>,
-    <ul class="dropdown-menu">
-        <li class="dropdown-header">{{ texts.SHOW_DETAILS }}</li>
-        <li>
-            <ul class="metricTable">
-                <li>
-                    <a href="citation-journal/{{ doc.id }}/?lang={{ lang }}" data-toggle="modal" data-placement="top" data-target="#CitationJournalInfo">
-                        <div class="logo-statistc logo-statistc-info"></div>
-                    </a>
-                </li>
-                <li>
-                    <a href="citation-journal/{{ doc.id }}/?lang={{ lang }}" data-toggle="modal" data-target="#CitationJournalInfo">
-                        {{ texts.ABOUT_JOURNAL }}
-                    </a>
-                </li>
-            </ul>
-        </li>
-    </ul>
+    <a href="citation-journal/{{ doc.id }}/?lang={{ lang }}" data-toggle="modal" data-placement="top" data-target="#CitationJournalInfo">{{ doc.cit_journal_title }}</a>,
 {% endif %}
 
 <!-- Citation journal volume and number -->


### PR DESCRIPTION
#### O que esse PR faz?
Remove menu para acessar painel de informações adicionais de periódico citado. 
O menu é desnecessário pois só há um link possível para ser acessado - E além disso, está fora de posicionamento. Para mais informações, consulte a _issue_ [https://github.com/scieloorg/search-references-experiment/issues/50](https://github.com/scieloorg/search-references-experiment/issues/50).

#### Onde a revisão poderia começar?
Por commit.

#### Como este poderia ser testado manualmente?
- Ter módulo search instalado;
- Ter referências citadas indexadas; 
- Ter dados de normalização de periódicos incluídas na indexação.

#### Algum cenário de contexto que queira dar?
O menu havia sido projeto para ter coerência com o que hoje existe para os artigos SciELO. Porém, naquele caso, faz sentido existir o menu porque ele dá acesso a mais de um link. No contexto das referências citadas, o menu só contem um link, o que atrasa a interação com o usuário.

### Screenshots
**Antes**
Ao clicar em "Biometrics", mostra um menu para acessar um link com as informações extras do periódico citado: 
![image](https://user-images.githubusercontent.com/2096125/88421437-f8362600-cdbe-11ea-8f4c-3f7933bfa120.png)

**Depois**
Ao clicar em "Biometrics", acessa direamtente as informações extras do periódico citado:
![image](https://user-images.githubusercontent.com/2096125/88421526-1734b800-cdbf-11ea-8f54-e4ebf179b232.png)


#### Quais são tickets relevantes?
[https://github.com/scieloorg/search-references-experiment/issues/50](https://github.com/scieloorg/search-references-experiment/issues/50)

### Referências
N/A

