### PR TITLE
Bug542 - Melhora a tokenização dos termos na pesquisa.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .DS_Store
 
 iahx/logs/*.txt
+iahx-sites/scieloorg/logs/
+node_modules
 
 solr/8.5.1/cores/solrdata/data/articles/data
 solr/8.5.1/cores/solrdata/logs

--- a/solr/8.5.1/cores/solrdata/data/articles/conf/managed-schema
+++ b/solr/8.5.1/cores/solrdata/data/articles/conf/managed-schema
@@ -23,8 +23,8 @@
       <!-- Author **from:au to:author** -->
       <field name="au" type="author" indexed="true" stored="true" multiValued="true"/>
 
-      <!-- Original Title **from:ti to:original_title** -->
-      <field name="ti" type="text" indexed="true" stored="true" multiValued="true"/>
+      <!-- Original Title **from:ti to:original_title**, using the text -->
+      <field name="ti" type="text_ws" indexed="true" stored="true" multiValued="true"/>
 
       <!-- Abstract **from:ab to:abstract** -->
       <field name="ab" type="text" indexed="true" stored="false" multiValued="true"/>
@@ -140,7 +140,7 @@
       <dynamicField name="ab_*"  type="text" indexed="false" stored="true"  multiValued="true"/>
 
       <!-- Dynamic Field to Title in any languages **from:title_in_* to:title_in_* ** -->
-      <dynamicField name="ti_*"  type="text" indexed="false" stored="true"  multiValued="true"/>
+      <dynamicField name="ti_*"  type="text_ws" indexed="false" stored="true"  multiValued="true"/>
 
       <!-- Field to journal CNPQ subject areas -->
       <field name="subject_area"  type="string" indexed="true" stored="true"  multiValued="true"/>
@@ -167,7 +167,7 @@
       <field name="use_license_uri"  type="string" indexed="false" stored="true"  multiValued="false"/>
 
       <!-- Text Words (All indexes) -->
-      <field name="tw" type="text" indexed="true" stored="false" multiValued="true"/>
+      <field name="tw" type="text_ws" indexed="true" stored="false" multiValued="true"/>
 
 
       <!-- Document Foreign Indexes -->
@@ -384,6 +384,22 @@
         </analyzer>
         <analyzer type="query">
           <tokenizer class="solr.StandardTokenizerFactory"/>
+          <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+          <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+          <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="false" />
+          <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+      </fieldType>
+
+      <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100" multiValued="true">
+        <analyzer type="index">
+          <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+          <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
+          <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="false" />
+          <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+          <tokenizer class="solr.WhitespaceTokenizerFactory"/>
           <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" />
           <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
           <filter class="solr.ASCIIFoldingFilterFactory" preserveOriginal="false" />


### PR DESCRIPTION
#### O que esse PR faz?

Melhora a "tokenização" dos termos na pesquisa.

Esse PR garante que seja encontrado registro com termos utilizando **"-"**, exemplos: 

- SARS-COVID-19 transformed the world and urological practice 
- The Social, Economic and Sanitary Impact of COVID-19 Pandemic
- The SARS-CoV-2 Coronavirus and the COVID-19 Outbreak

#### Onde a revisão poderia começar?

Por commit. 

#### Como este poderia ser testado manualmente?

Irei atualizar o ambiente de homologação com esse ajuste para que a validação seja mais fácil. 

#### Algum cenário de contexto que queira dar?

Para ter o efeito desejado será necessário a re-indexação do índice.

### Screenshots

Buscando por um termo que anteriormente não funcionava: 

![Captura de Tela 2021-08-05 às 14 24 11](https://user-images.githubusercontent.com/86991526/128394130-e97df601-eca9-4c04-a770-51abc6615896.png)


#### Quais são tickets relevantes?
#542 

### Referências

Material para apoio a solução: 

- https://stackoverflow.com/questions/18277609/search-in-solr-with-special-characters
- https://stackoverflow.com/questions/12620386/special-characters-etc-not-working-in-solr-query
- https://solr.apache.org/guide/6_6/tokenizers.html

