### PR TITLE
Adiciona o numero de suplemento na interface do resultado de pesquisa.

### DIFF
--- a/iahx-sites/scieloorg/locale/en/texts.ini
+++ b/iahx-sites/scieloorg/locale/en/texts.ini
@@ -407,6 +407,7 @@ LABEL_LOCALIZATION="Localization"
 LABEL_RESPONSIBLE="Responsible library"
 LABEL_VOLUME="Volume"
 LABEL_NUMBER="N."
+LABEL_SUPPLEMENT="Suppl."
 LABEL_PAGES="Pages"
 LABEL_PUBLICATION_DATE="Publication date"
 

--- a/iahx-sites/scieloorg/locale/es/texts.ini
+++ b/iahx-sites/scieloorg/locale/es/texts.ini
@@ -634,6 +634,7 @@ LABEL_LOCALIZATION="Ubicación"
 LABEL_RESPONSIBLE="Biblioteca responsable"
 LABEL_VOLUME="Volumen"
 LABEL_NUMBER="Nº"
+LABEL_SUPPLEMENT="Supl."
 LABEL_PAGES="Paginas"
 LABEL_PUBLICATION_DATE="Fecha de publicación"
 

--- a/iahx-sites/scieloorg/locale/pt/texts.ini
+++ b/iahx-sites/scieloorg/locale/pt/texts.ini
@@ -641,6 +641,7 @@ LABEL_TYPE=Tipo
 LABEL_PUBLICATION="Tipo de publicação"
 LABEL_VOLUME="Volume"
 LABEL_NUMBER="Nº"
+LABEL_SUPPLEMENT="Supl."
 LABEL_PAGES="Páginas"
 LABEL_PUBLICATION_DATE="Data de publicação"
 

--- a/iahx-sites/scieloorg/templates/custom/result-inc-source.html
+++ b/iahx-sites/scieloorg/templates/custom/result-inc-source.html
@@ -55,9 +55,15 @@
         <small>{{ texts.RESULT.LABEL_VOLUME }}</small>
         <span>{{ doc.volume }}</span>
     {% endif %}
+
     {% if doc.issue %}
-        <small><small>{{ texts.RESULT.LABEL_NUMBER }}</small></small>
+        <small>{{ texts.RESULT.LABEL_NUMBER }}</small>
         <span>{{ doc.issue }}</span>
+    {% endif %}
+
+    {% if doc.supplement_volume %}
+        <small>{{ texts.RESULT.LABEL_SUPPLEMENT }}</small>
+        <span>{{ doc.supplement_volume }}</span>
     {% endif %}
 
     {% if doc.elocation %}


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o numero de suplemento na interface do resultado de pesquisa.

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Sugiro rodar localmente a aplicação e avaliar os retorno que contenha suplemento com a sequinte pesquisa: 

```
supplement_volume:*
```

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

Formato do retorno no resultado de pesquisa: 

![Captura de Tela 2021-08-13 às 14 07 55](https://user-images.githubusercontent.com/86991526/129395904-d0a6eed2-7acf-4db8-b0c0-b13b6a5484c8.png)


#### Quais são tickets relevantes?

#545 

### Referências
N/A

