### PR TITLE
Remove as avaliações ``detailed_query`` que realiza alterações na interface.

### DIFF
--- a/iahx-sites/scieloorg/templates/custom/index.html
+++ b/iahx-sites/scieloorg/templates/custom/index.html
@@ -8,7 +8,6 @@
         <div id="flash" style="display: none;">{{ attribute(texts, flash_message) }}</div>
     {% endif %}
 
-    {% if detailed_query != '' and docs|length > 0 %}
         {% block results %}
             <div class="searchForm">
                 <div class="container resultBlock">
@@ -71,8 +70,6 @@
             <span class='st_googleplus' displayText='Google+'></span>
             <span class='st_sharethis' displayText='ShareThis'></span>
         </div>
-
-    {% endif %}
 
     <div class="modal fade" id="NotFound" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal-sm">

--- a/iahx-sites/scieloorg/templates/custom/top-searchbar.html
+++ b/iahx-sites/scieloorg/templates/custom/top-searchbar.html
@@ -19,21 +19,10 @@
 
 </form>
 <form name="searchFormBuilder" class="searchFormBuilder searchForm">
-    <div class="highlight {% if detailed_query != '' %}result{% endif %}">
+    <div class="highlight result">
         <div class="container">
-            <!--a href="" class="help" data-toggle="modal" data-target="#Help" style="margin-left: 20px;">{{ texts.HELP }}</a-->
 
-            {% if detailed_query == '' %}
-                <div class="col-md-8 col-md-offset-1 col-sm-6 col-sm-offset-1">
-                    <h2>{{ texts.SEARCH_ARTICLES }}</h2>
-                </div>
-                <div class="col-md-2 col-sm-2">
-
-                </div>
-                <div class="clearfix"></div>
-            {% endif %}
-
-            <div class="col-md-8 col-sm-8 {% if detailed_query == '' %}col-md-offset-1 col-sm-offset-1{% endif %}">
+            <div class="col-md-8 col-sm-8">
                 <a href="" class="contextHelper" data-toggle="modal" id="contextHelper1" data-target="#BuscaAjuda">
                     {{ texts.NEED }} <strong>{{ texts.HELP }}</strong>?
                 </a>
@@ -63,18 +52,14 @@
             <div class="col-md-2 col-sm-2">
                 <input type="submit" name="search_button" value="{{ texts.SEARCH_SUBMIT }}" class="btn btn-primary glyph glyph-search">
             </div>
-            {% if detailed_query != '' %}
-                <div class="col-md-1 col-sm-1">
-                    <a href="{{ constant("SEARCH_URL") }}?lang={{lang}}" class="normalizeButton">» {{ texts.NEW_SEARCH }}</a>
-                </div>
-            {% endif %}
+
             <div class="clearfix"></div>
 
             <div class="searchRow-container">
 
             </div>
 
-            <div class="{% if detailed_query == '' %}col-md-7 col-sm-7{% else %}col-md-6 col-sm-6{% endif %} right">
+            <div class="col-md-6 col-sm-6 right">
                 <a href="" class="newSearchField" data-count="2">{{ texts.ADD_FIELD }}</a>
             </div>
             <div class="col-md-3  col-md-offset-2 col-sm-3">
@@ -95,7 +80,7 @@
             <div class="col-md-1 col-sm-1 right">
                 <a href="" class="eraseSearchField" data-rel="" title="Apagar campo"></a>
             </div>
-            <div class="{% if detailed_query == '' %}col-md-8 col-sm-8{% else %}col-md-7 col-sm-7{% endif %}">
+            <div class="col-md-7 col-sm-7">
                 <div class="input-group col-md-12 col-sm-12">
                     <div class="selectBox connector">
                         <select name="bool[]">

--- a/iahx-sites/scieloorg/templates/custom/top.html
+++ b/iahx-sites/scieloorg/templates/custom/top.html
@@ -2,17 +2,13 @@
 <div class="container">
     <div class="topFunction">
         <div class="col-md-3 col-sm-4 mainNav">
-
            {% include custom_template('top-menu-' ~ lang ~ '.html') %}
+        </div>
 
+        <div class="col-md-6 col-sm-4 brandLogo brandLogoInternal">
+            <a href="{{ config.bvs_url }}"></a>
         </div>
-        
-        <div class="col-md-6 col-sm-4 brandLogo {% if detailed_query != '' %}brandLogoInternal{% endif %}">      
-            <a href="{{ config.bvs_url }}" >
-                {% if detailed_query == '' %}<span>Scientific Electronic Library Online</span>{% endif %}
-            </a>
-        </div>
-        
+
         <div class="col-md-3 col-sm-4 language">
             {% for langcode, item in texts.AVAILABLE_LANGUAGES %}
                 <a href="javascript:change_language('{{ langcode|lower }}')" {% if langcode|lower == lang %} class="selected" {% endif %} class="lang-{{ langcode|lower }}">{{ item }}</a>

--- a/iahx/views/list_filter.php
+++ b/iahx/views/list_filter.php
@@ -37,7 +37,7 @@ $app->get('list-filter/{filter_id}', function (Request $request, $filter_id) use
 
     $dia = new Dia($site, $col, 1, 'site', $lang);
     $dia->setParam('fb', $fb);
-    $dia->setParam('initial_filter', $initial_filter );
+    $dia->setParam('initial_filter', $initial_filter);
 
     $dia_response = $dia->search($q, $index, $filter);
     $result = json_decode($dia_response, true);


### PR DESCRIPTION
#### O que esse PR faz?
Remove a tela inicial do sistema de pesquisa

![Captura de Tela 2021-12-16 às 09 56 27](https://user-images.githubusercontent.com/86991526/146376135-e283b85c-9151-464c-9fab-32212222f61e.png)


#### Onde a revisão poderia começar?
No templates alterados 

#### Como este poderia ser testado manualmente?

Executando: **docker-compose -f dokcer-compose-dev.yml up -d**

Acessnado http://localhost e verificando que iremos direto para a tela: 

![Captura de Tela 2021-12-16 às 09 57 53](https://user-images.githubusercontent.com/86991526/146376306-40b037aa-a325-4904-988b-843d7f9bedfa.png)


#### Algum cenário de contexto que queira dar?

A avaliação do parâmetro `detailed_query ` é um erro de desenho da solução. 

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A

