### PR TITLE
Remove o link para e-pdf e remove trecho que utiliza o campo ``fulltext_pdf_LANG`` para exibir ou não o links para PDFs.

### DIFF
--- a/iahx-sites/scieloorg/templates/custom/result-doc-actions.html
+++ b/iahx-sites/scieloorg/templates/custom/result-doc-actions.html
@@ -56,9 +56,9 @@
                 -->
                 {% for language in doc.available_languages %}
 
-                    {% set pdf_lang = 'fulltext_pdf_' ~ language %}
+                    {#% set pdf_lang = 'fulltext_pdf_' ~ language %}
 
-                    {% if attribute(doc, pdf_lang) %}
+                    {% if attribute(doc, pdf_lang) %#}
                         <span class="separator">|</span>
                         <span>
 
@@ -67,20 +67,9 @@
                                 {{ translate(language) }}
                             </a>
 
-                            {% if doc.doi and doc.in.0 == 'scl' %}
-
-                                <span class="separator">|</span>
-                                <span class="e-pdf">
-                                    ePDF:
-                                    <a href="{{ attribute(config.scielo_urls, doc.in.0) }}/readcube/epdf.php?doi={{doc.doi}}&pid={{doc.ur.0}}&pdf_path={{ attribute(doc, pdf_lang).0|substring_after('pdf/') }}&lang={{language}}" class="showTooltip" title="{{ translate(language, 'REFINE_la') }}">
-                                        {{ translate(language) }}
-                                    </a>
-                                </span>
-                            {% endif %}
-
                         </span>
 
-                     {% endif %}
+                     {#% endif %#}
 
                 {% endfor %}
             {% endif %}

--- a/iahx/views/chart.php
+++ b/iahx/views/chart.php
@@ -11,7 +11,7 @@ $app->match('chart/', function (Request $request) use ($app, $DEFAULT_PARAMS, $c
         $app['request']->query->all()
     );
 
-    if(!isset($params['d']) or !isset($params['l']) or !isset($params['title'])) 
+    if(!isset($params['d']) or !isset($params['l']) or !isset($params['title']))
         die;
 
     $data = $params['d'];
@@ -39,7 +39,7 @@ $app->match('chart/', function (Request $request) use ($app, $DEFAULT_PARAMS, $c
 
     if ($sort == true){
         array_multisort($labels,$data);
-    }  
+    }
 
     if ($type == 'line'){
 
@@ -55,20 +55,20 @@ $app->match('chart/', function (Request $request) use ($app, $DEFAULT_PARAMS, $c
     }else if ($type == 'pie'){
 
         $g->pie(60,'#505050','{font-size: 11px; color: #404040}');
-        
+
         $g->pie_values( $data, $labels );
         $g->pie_slice_colours( array('#d01f3c','#356aa0','#C79810','#FFCC99','#009933','#FF99FF','#33FFFF','#CCCC99','#330033','#00CCFF','#CCCCCC','#FFCC00','#FF0033','#660000','#FFCCCC','#33FF33','#FF6633' ) );
 
     }else if ($type == 'export-csv'){
 
-        $csv_out =  "Label,Value\r\n";
+        $csv_out = $title . ",Total\r\n";
         for ( $i = 0; $i < count($data); $i++ ){
             $csv_out .= '"' . $labels[$i] . '","' . $data[$i] . '"' . "\r\n";
         }
         $response = new Response($csv_out);
         $response->headers->set('Content-Encoding', 'UTF-8');
         $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
-        header('Content-Disposition: attachment; filename=export_cluster.csv');
+        header('Content-Disposition: attachment; filename=export_cluster_' . date('dmY') .  '.csv');
         echo "\xEF\xBB\xBF"; // UTF-8 BOM
         return $response->sendHeaders();
 
@@ -76,29 +76,29 @@ $app->match('chart/', function (Request $request) use ($app, $DEFAULT_PARAMS, $c
 
         $bar = new bar( 95, '#5E83BF', '#424581' );
         //$bar->key( 'documentos', 10 );
-        
+
         $bar->data = $data;
-        
+
         // set the X axis labels
         $g->set_x_labels( $labels );
-        
+
         //$g->set_data( $data );
         //$g->bar_sketch( 50, 6, '#99FF00', '#7030A0', '% Complete', 10 );
         // add the bar object to the graph
         //
         $g->data_sets[] = $bar;
-        
+
         $g->set_x_max(count($labels));
         $g->set_x_min(count($labels));
-        
+
         $g->set_x_label_style( 11, '#A0A0A0', 2 );
         $g->set_y_label_style( 11, '#A0A0A0' );
         $g->x_axis_colour( '#A0A0A0', '#FFFFFF' );
-        
+
         //$g->set_x_legend( 'Week 1', 12, '#A0A0A0' );
         $g->y_axis_colour( '#A0A0A0', '#FFFFFF' );
-        
-        
+
+
         $g->set_y_min( min($data) );
         $g->set_y_max( max($data) );
         $g->y_label_steps( 2 );

--- a/iahx/views/chartjs.php
+++ b/iahx/views/chartjs.php
@@ -10,12 +10,13 @@ $app->match('chartjs/', function (Request $request) use ($app, $DEFAULT_PARAMS, 
         $app['request']->query->all()
     );
 
-    if(!isset($params['d']) or !isset($params['l'])) 
+    if(!isset($params['d']) or !isset($params['l']))
         die;
 
     $data = $params['d'];
     $labels = $params['l'];
     $title = $params['title'];
+
 
     $type = "";
     if(isset($params['type'])) {
@@ -31,18 +32,18 @@ $app->match('chartjs/', function (Request $request) use ($app, $DEFAULT_PARAMS, 
 
     if ($sort == true){
         array_multisort($labels,$data);
-    }  
+    }
 
     if ($type == 'export-csv'){
 
-        $csv_out =  "Label,Value\r\n";
+        $csv_out =  $title . ",Total\r\n";
         for ( $i = 0; $i < count($data); $i++ ){
             $csv_out .= '"' . $labels[$i] . '","' . $data[$i] . '"' . "\r\n";
         }
         $response = new Response($csv_out);
         $response->headers->set('Content-Encoding', 'UTF-8');
         $response->headers->set('Content-Type', 'text/csv; charset=UTF-8');
-        header('Content-Disposition: attachment; filename=export_cluster.csv');
+        header('Content-Disposition: attachment; filename=export_cluster_' . date('dmY') .  '.csv');
         echo "\xEF\xBB\xBF"; // UTF-8 BOM
         return $response->sendHeaders();
 
@@ -57,7 +58,7 @@ $app->match('chartjs/', function (Request $request) use ($app, $DEFAULT_PARAMS, 
                   . '   "datasets" : ['
                   . '       { '
                   . '           "fillColor" : "#5DC55D", '
-                  . '           "strokeColor" : "#5DC55D", ' 
+                  . '           "strokeColor" : "#5DC55D", '
                   . '           "highlightFill": "#348734", '
                   . '           "highlightStroke": "#348734",'
                   . '           "data" : ' . json_encode($data)
@@ -78,15 +79,15 @@ $app->match('chartjs/', function (Request $request) use ($app, $DEFAULT_PARAMS, 
                 $json .= ' "color": "' . $colors[$i] . '"}';
                 if ($i < ($l_total-1) ){
                   $json .= ',';
-                } 
+                }
             }
             $json .= "]";
         }
-        
+
         echo $json;
-        
+
         return $response->sendHeaders();
-    }   
+    }
 
 });
 


### PR DESCRIPTION
#### O que esse PR faz?
Remove o link para e-pdf e remove trecho que utiliza o campo ``fulltext_pdf_LANG`` para exibir ou não o links para PDFs.

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Ao acessar o resultado de pesquisa é possível ver que os links para pdfs estão disponíveis.

#### Algum cenário de contexto que queira dar?

É necessário garantir que o param **lng** no link legado seja utilizado no OPAC para obter o idioma correto. Aberto um tíquete no OPAC para resolver: https://github.com/scieloorg/opac/issues/2168

### Screenshots
N/A.

#### Quais são tickets relevantes?
#539

### Referências
N/A.

